### PR TITLE
Add a way to build via Docker to enable building on macOS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.DS_Store
+.git
+.github
+
+# Local build output
+build
+**/build
+
+# Editor / tooling
+.idea
+.vscode
+**/__pycache__
+**/*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# BuildKit automatically provides these at build time, but declare them so they can be used.
+ARG TARGETARCH
+
+ARG BOUFFALO_SDK_REPO="https://github.com/nand2mario/bouffalo_sdk.git"
+ARG BOUFFALO_SDK_DIR="/opt/bouffalo_sdk"
+
+# Bouffalo's prebuilt (T-Head) toolchain is typically x86_64-only. On non-amd64 images we fall back to the
+# distro-provided riscv64-unknown-elf toolchain (works well for many setups, and runs native on Apple Silicon).
+ARG BFLB_THEAD_TOOLCHAIN_REPO="https://github.com/bouffalolab/toolchain_gcc_t-head_linux.git"
+ARG BFLB_THEAD_TOOLCHAIN_DIR="/opt/toolchain_gcc_t-head_linux"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cmake \
+    file \
+    git \
+    ninja-build \
+    openssl \
+    python-is-python3 \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN if [[ "${TARGETARCH:-}" == "amd64" ]]; then \
+      git clone --depth 1 "${BFLB_THEAD_TOOLCHAIN_REPO}" "${BFLB_THEAD_TOOLCHAIN_DIR}"; \
+    else \
+      apt-get update && apt-get install -y --no-install-recommends \
+        binutils-riscv64-unknown-elf \
+        gcc-riscv64-unknown-elf \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules \
+    "${BOUFFALO_SDK_REPO}" "${BOUFFALO_SDK_DIR}"
+
+# Common Python deps used by Bouffalo tooling (build still works if the SDK doesn't need them).
+RUN python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir \
+      ecdsa \
+      pycryptodome \
+      pyserial \
+      pyyaml
+
+ENV BL_SDK_BASE="${BOUFFALO_SDK_DIR}"
+ENV PATH="${BFLB_THEAD_TOOLCHAIN_DIR}/bin:${PATH}"
+
+WORKDIR /work
+CMD ["make"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ The 2nd line flashes the firmware to BL616 (The required `bl616_fpga_partner_60k
 
 For the USB drive, You need an OTG dongle to turn the connector from a "device" one to a "host" one, and provide power at the same time.
 
+## Build with Docker (macOS / Linux)
+
+Build the image:
+
+```bash
+docker build -t firmware-bl616-builder . --load
+```
+
+Then run `make` inside the container (outputs will be written into your working tree, e.g. `./build`):
+
+```bash
+docker run --rm -v "$PWD":/work -w /work firmware-bl616-builder
+```
+
+On Apple Silicon, if you hit toolchain issues, try forcing x86 emulation:
+
+```bash
+docker build --platform linux/amd64 -t firmware-bl616-builder . --load
+docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work firmware-bl616-builder
+```
+
 Acknowledgements
 * JTAG FPGA programming logic based on [openFPGALoader](https://github.com/trabucayre/openFPGALoader)
 * Gamepad support based on Till Harbaum's [FPGA-Companion](https://github.com/harbaum/FPGA-Companion)


### PR DESCRIPTION
This makes it possible to easily build the firmware on any system that has docker support, which by now includes windows and macos.